### PR TITLE
Add support for BigInt typed arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,12 @@ var names = {
     '[object Int8Array]': true
   , '[object Int16Array]': true
   , '[object Int32Array]': true
+  , '[object BigInt64Array]': true
   , '[object Uint8Array]': true
   , '[object Uint8ClampedArray]': true
   , '[object Uint16Array]': true
   , '[object Uint32Array]': true
+  , '[object BigUint64Array]': true
   , '[object Float32Array]': true
   , '[object Float64Array]': true
 }
@@ -27,10 +29,12 @@ function isStrictTypedArray(arr) {
        arr instanceof Int8Array
     || arr instanceof Int16Array
     || arr instanceof Int32Array
+    || arr instanceof BigInt64Array
     || arr instanceof Uint8Array
     || arr instanceof Uint8ClampedArray
     || arr instanceof Uint16Array
     || arr instanceof Uint32Array
+    || arr instanceof BigUint64Array
     || arr instanceof Float32Array
     || arr instanceof Float64Array
   )

--- a/test.js
+++ b/test.js
@@ -10,6 +10,8 @@ test('strict', function(t) {
   t.ok(ista.strict(new Uint32Array), 'Uint32Array')
   t.ok(ista.strict(new Float32Array), 'Float32Array')
   t.ok(ista.strict(new Float64Array), 'Float64Array')
+  t.ok(ista.strict(new BigInt64Array), 'BigInt64Array')
+  t.ok(ista.strict(new BigUint64Array), 'BigUint64Array')
 
   t.ok(!ista.strict(new Array), 'Array')
   t.ok(!ista.strict([]), '[]')
@@ -26,6 +28,8 @@ test('loose', function(t) {
   t.ok(ista.loose(new Uint32Array), 'Uint32Array')
   t.ok(ista.loose(new Float32Array), 'Float32Array')
   t.ok(ista.loose(new Float64Array), 'Float64Array')
+  t.ok(ista.loose(new BigInt64Array), 'BigInt64Array')
+  t.ok(ista.loose(new BigUint64Array), 'BigUint64Array')
 
   t.ok(!ista.loose(new Array), 'Array')
   t.ok(!ista.loose([]), '[]')


### PR DESCRIPTION
`BigInt64Array` and `BigUint64Array` should be detected by this module because they are typed arrays.